### PR TITLE
CI: trying to autobuild work (3)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -52,8 +52,6 @@ jobs:
           title: "[AUTOBUILD] ${{ steps.date.outputs.date }}"
           body: "Auto-generated update to dist/ from latest main push"
           base: main
-          labels: |
-            autobuild
           commit-message: "autobuild"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           delete-branch: true


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove the `autobuild` label from the GitHub Actions workflow for autobuild.

### Why are these changes being made?
The removal of the `autobuild` label simplifies the workflow configuration by no longer applying a label to auto-generated updates, which may not provide significant benefit in distinguishing these updates. This streamlining ensures clarity and reduces unnecessary configurations in the CI process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->