### PR TITLE
CI: trying to autobuild work (4)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -64,12 +64,20 @@ jobs:
         with:
           time: 30s
 
-      - name: Auto-merge PR
+      - name: Wait for all checks to complete
         if: ${{ steps.create_pr.outputs.pull-request-number }}
-        uses: pascalgn/automerge-action@v0.15.0
+        id: wait-for-checks
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ steps.create_pr.outputs.pull-request-head-sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+          allowed-conclusions: success,skipped
+
+      - name: Auto-merge PR if checks pass
+        if: ${{ steps.create_pr.outputs.pull-request-number && success() }}
+        run: |
+          gh pr merge ${{ steps.create_pr.outputs.pull-request-number }} --merge --auto
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: autobuild
-          MERGE_METHOD: squash
-          MERGE_DELETE_BRANCH: "true"
-          MERGE_COMMIT_MESSAGE: pull-request-title
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace the auto-merge PR step with a two-step process that waits for all checks to complete before automatically merging the PR if checks pass.

### Why are these changes being made?

The current setup relies on immediately attempting an auto-merge, which may not account for asynchronous check completions, potentially leading to incorrect merges. Using `wait-on-check-action` ensures that only pull requests with successful checks are merged, providing a more reliable CI process and mitigating premature merges.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->