### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,6 +13,9 @@ jobs:
   merge:
     name: "Merge"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      pull-requests: write
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION
Potential fix for [https://github.com/impresscms-dev/strip-markdown-extensions-from-links-action/security/code-scanning/4](https://github.com/impresscms-dev/strip-markdown-extensions-from-links-action/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow performs read and write operations on pull requests and repository contents, we will grant the minimal required permissions: `contents: read` and `pull-requests: write`. These permissions will be added at the job level to ensure they apply only to the `merge` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
